### PR TITLE
From doc.nais.io: You cannot have a application using the same ingres…

### DIFF
--- a/nais/nais-dev-gcp.yml
+++ b/nais/nais-dev-gcp.yml
@@ -10,13 +10,14 @@ spec:
   port: 8080
   replicas:
     min: 1
-    max: 2
+    max: 1
   liveness:
     path: "/api/internal/isAlive"
     initialDelay: 35
     timeout: 3
   ingresses:
-    - "https://pensjon-brevmetadata.dev.adeo.no"
+    - "https://pensjon-brevmetadata-gcp.dev.adeo.no"
+    - "https://pensjon-brevmetadata-gcp.dev-gcp.nais.io"
   readiness:
     path: "/api/internal/isReady"
     initialDelay: 35


### PR DESCRIPTION
…s in both clusters, as the explicit record created will always override the wildcard ingress.