### PR TITLE
Update access rules Pensjon

### DIFF
--- a/nais/dev-prodlik.yaml
+++ b/nais/dev-prodlik.yaml
@@ -9,12 +9,24 @@ inboundRules:
   - name: pensjon-pen-q0
     namespace: teampensjon
     cluster: dev-fss
+  - name: pensjon-pen-q0
+    namespace: pensjon-q0
+    cluster: dev-fss
   - name: pensjon-psak-q0
     namespace: teampensjon
     cluster: dev-fss
-  - name: pensjon-pselv-q0
-    namespace: teampensjon
+  - name: pensjon-psak-q0
+    namespace: pensjon-q0
     cluster: dev-fss
   - name: pensjon-pselv-q0
     namespace: teampensjon
+    cluster: dev-fss
+  - name: pensjon-pselv-veileder-q0
+    namespace: pensjon-q0
+    cluster: dev-gcp
+  - name: pensjon-pselv-q0
+    namespace: teampensjon
+    cluster: dev-gcp
+  - name: pensjon-pselv-borger-q0
+    namespace: pensjon-q0
     cluster: dev-gcp

--- a/nais/dev-q1.yaml
+++ b/nais/dev-q1.yaml
@@ -9,14 +9,26 @@ inboundRules:
   - name: pensjon-pen-q1
     namespace: teampensjon
     cluster: dev-fss
+  - name: pensjon-pen-q1
+    namespace: pensjon-q1
+    cluster: dev-fss
   - name: pensjon-psak-q1
     namespace: teampensjon
     cluster: dev-fss
-  - name: pensjon-pselv-q1
-    namespace: teampensjon
+  - name: pensjon-psak-q1
+    namespace: pensjon-q1
     cluster: dev-fss
   - name: pensjon-pselv-q1
     namespace: teampensjon
+    cluster: dev-fss
+  - name: pensjon-pselv-veileder-q1
+    namespace: pensjon-q1
+    cluster: dev-gcp
+  - name: pensjon-pselv-q1
+    namespace: teampensjon
+    cluster: dev-gcp
+  - name: pensjon-pselv-borger-q1
+    namespace: pensjon-q1
     cluster: dev-gcp
   - name: pensjon-testdata-server-q1
     namespace: pensjontestdata

--- a/nais/dev-q2.yaml
+++ b/nais/dev-q2.yaml
@@ -9,14 +9,26 @@ inboundRules:
   - name: pensjon-pen-q2
     namespace: teampensjon
     cluster: dev-fss
+  - name: pensjon-pen-q2
+    namespace: pensjon-q2
+    cluster: dev-fss
   - name: pensjon-psak-q2
     namespace: teampensjon
     cluster: dev-fss
-  - name: pensjon-pselv-q2
-    namespace: teampensjon
+  - name: pensjon-psak-q2
+    namespace: pensjon-q2
     cluster: dev-fss
   - name: pensjon-pselv-q2
     namespace: teampensjon
+    cluster: dev-fss
+  - name: pensjon-pselv-veileder-q2
+    namespace: pensjon-q2
+    cluster: dev-gcp
+  - name: pensjon-pselv-q2
+    namespace: teampensjon
+    cluster: dev-gcp
+  - name: pensjon-pselv-borger-q2
+    namespace: pensjon-q2
     cluster: dev-gcp
   - name: pensjon-testdata-server-q2
     namespace: pensjontestdata

--- a/nais/dev-q4.yaml
+++ b/nais/dev-q4.yaml
@@ -6,18 +6,6 @@ replicas:
   min: 1
   max: 2
 inboundRules:
-  - name: pensjon-pen-q4
-    namespace: teampensjon
-    cluster: dev-fss
-  - name: pensjon-psak-q4
-    namespace: teampensjon
-    cluster: dev-fss
-  - name: pensjon-pselv-q4
-    namespace: teampensjon
-    cluster: dev-fss
-  - name: pensjon-pselv-q4
-    namespace: teampensjon
-    cluster: dev-gcp
   - name: pensjon-testdata-server-q4
     namespace: pensjontestdata
     cluster: dev-fss

--- a/nais/dev-q5.yaml
+++ b/nais/dev-q5.yaml
@@ -9,14 +9,26 @@ inboundRules:
   - name: pensjon-pen-q5
     namespace: teampensjon
     cluster: dev-fss
+  - name: pensjon-pen-q5
+    namespace: pensjon-q5
+    cluster: dev-fss
   - name: pensjon-psak-q5
     namespace: teampensjon
     cluster: dev-fss
-  - name: pensjon-pselv-q5
-    namespace: teampensjon
+  - name: pensjon-psak-q5
+    namespace: pensjon-q5
     cluster: dev-fss
   - name: pensjon-pselv-q5
     namespace: teampensjon
+    cluster: dev-fss
+  - name: pensjon-pselv-veileder-q5
+    namespace: pensjon-q5
+    cluster: dev-gcp
+  - name: pensjon-pselv-q5
+    namespace: teampensjon
+    cluster: dev-gcp
+  - name: pensjon-pselv-borger-q5
+    namespace: pensjon-q5
     cluster: dev-gcp
   - name: pensjon-testdata-server-q5
     namespace: pensjontestdata

--- a/nais/prod.yaml
+++ b/nais/prod.yaml
@@ -15,6 +15,12 @@ inboundRules:
   - name: pensjon-pselv
     namespace: pensjondeployer
     cluster: prod-fss
+  - name: pensjon-pselv-veileder
+    namespace: pensjondeployer
+    cluster: prod-gcp
   - name: pensjon-pselv
+    namespace: pensjondeployer
+    cluster: prod-gcp
+  - name: pensjon-pselv-borger
     namespace: pensjondeployer
     cluster: prod-gcp


### PR DESCRIPTION
We are moving applications to new namespaces in order to lock down access to the test environments with production data.
Upcoming platform change makes it possible to lock down certain kubectl commands in given namespaces.

This PR is preparing namespace move for pen, psak, pselv and name change for pselv application (both pselv applications are going to gcp in the same namespace).

A cleanup PR will be made when the applications are moved.