### PR TITLE
Legg inn npm-konfig for docs

### DIFF
--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,0 +1,5 @@
+@navikt:registry=https://npm.pkg.github.com
+
+allow-git=none       # block install via git to avoid script overrides
+ignore-scripts=true  # block pre-install and post-install scripts
+min-release-age=7    # days cooldown: block installs released later


### PR DESCRIPTION
Samme .npmrc som i skribenten. Utløysande grunn til endringa er at dependabot ikkje klarte å lesa frå registeret utan, men det er uansett ei trygg og smart endring