### PR TITLE
build(deps): upgrade Jackson to 2.22.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
 }
 
 dependencies {
+    implementation(platform(libs.jackson.bom))
     implementation(libs.bundles.metrics)
     implementation(libs.ktor.serialization.jackson)
     implementation(libs.ktor.server.callId)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+jacksonVersion = "2.22.1"
 jupiterVersion = "6.1.1"
 kotlinVersion = "2.3.0"
 ktorVersion = "3.5.1"
@@ -9,6 +10,8 @@ org-skyscreamer-jsonassert = "1.5.3"
 
 [libraries]
 org-skyscreamer-jsonassert = { module = "org.skyscreamer:jsonassert", version.ref = "org-skyscreamer-jsonassert" }
+
+jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jacksonVersion" }
 
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "jupiterVersion" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "jupiterVersion" }


### PR DESCRIPTION
Pin Jackson to the newest 2.x release via jackson-bom platform import, overriding the transitive version (2.21.3) pulled in by ktor-serialization-jackson 3.5.1.


Motivert av at Jackson-versjonen som følgjer med transitivt har [sårbarheiter](https://console.nav.cloud.nais.io/team/pensjonsbrev/prod-gcp/app/pensjon-brevmetadata/vulnerabilities). Og den generelle lærdommen vi har fått i løpet av våren og sommaren at Jackson kan ha mykje sårbart i seg (relativt naturleg for den type bibliotek), så det er ein avhengnad vi gjerne vil kunne styre minor-/patch-versjon av sjølv.